### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-push-container.yaml
+++ b/.github/workflows/build-push-container.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: build tag from branch name
         run: echo ::set-output name=tag::jaypickle/godot-build:${GITHUB_REF##*/}
         id: tag
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ steps.tag.outputs.tag }}
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore